### PR TITLE
Folder handling

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
+	"github.com/AlexTLDR/FileSync/frontend"
 	"github.com/AlexTLDR/FileSync/metadata"
 	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
@@ -267,6 +268,10 @@ func cleanupEmptyFolders(ctx context.Context, localDir string, bucket *blob.Buck
 			return err
 		}
 		if !info.IsDir() {
+			return nil
+		}
+		// Skip the main sync folder
+		if path == frontend.Dir {
 			return nil
 		}
 		empty, err := isDirEmpty(path)


### PR DESCRIPTION
The focus was on the files and I encountered an issue. When I deleted a folder, on the other side only the files were deleted and empty folders remained.

ex: Locally I have a folder test, with 3 files. I go in the bucket, delete the test folder. Locally the 3 files from the test folder are deleted, but the empty test folder remains.

solution: a helper function that checks empty folders. If there is an empty folder locally but not on the bucket, it will be deleted (and vice versa).